### PR TITLE
Preview - pickup lastest changes to fzf.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+This is a fork of [fzf.vim](https://github.com/junegunn/fzf.vim)
+but for [skim](https://github.com/lotabout/skim). I'd like to take advanctage
+of fzf.vim as much as possible and only maintain the features where skim is
+not compatible with fzf.
+
 fzf :heart: vim
 ===============
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -634,6 +634,23 @@ function! s:ag_handler(lines, with_column)
   endif
 endfunction
 
+function! fzf#vim#ag_interactive(dir, ...)
+  let dir = empty(a:dir) ? '.' : a:dir
+  let opts = {
+  \ 'source':  "none",
+  \ 'column':  1,
+  \ 'options': ['-i', '-c', 'ag --nogroup --column --color '.get(g:, 'ag_opts', '').' "{}" ' . dir,
+  \             '--ansi', '--cmd-prompt', 'Ag> ',
+  \             '--multi', '--bind', 'alt-a:select-all,alt-d:deselect-all',
+  \             '--color', 'hl:68,hl+:110']
+  \}
+  function! opts.sink(lines)
+    return s:ag_handler(a:lines, self.column)
+  endfunction
+  let opts['sink*'] = remove(opts, 'sink')
+  return s:fzf('rg', opts, a:000)
+endfunction
+
 " query, [[ag options], options]
 function! fzf#vim#ag(query, ...)
   if type(a:query) != s:TYPE.string

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -642,7 +642,7 @@ endfunction
 
 function! fzf#vim#rg_interactive(dir, ...)
   let dir = empty(a:dir) ? '.' : a:dir
-  let command = 'rg --color=always --line-number '.get(g:, 'ag_opts', '').' "{}" ' . dir
+  let command = 'rg --column --line-number --color=always '.get(g:, 'rg_opts', '').' "{}" ' . dir
   return call('fzf#vim#grep_interactive', extend([command, 1], a:000))
 endfunction
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -588,7 +588,7 @@ function! fzf#vim#buffers(...)
   return s:fzf('buffers', {
   \ 'source':  map(s:buflisted_sorted(), 's:format_buffer(v:val)'),
   \ 'sink*':   s:function('s:bufopen'),
-  \ 'options': '-m --tiebreak=index --ansi -d "\t" -n 2,1..2 --prompt="Buf> "'.s:q(query)
+  \ 'options': '-m --tiebreak=index --ansi -d "\t" -n 0,1,2 --prompt="Buf> "'.s:q(query)
   \}, args)
 endfunction
 
@@ -782,7 +782,7 @@ function! fzf#vim#buffer_tags(query, ...)
     return s:fzf('btags', {
     \ 'source':  s:btags_source(tag_cmds),
     \ 'sink*':   s:function('s:btags_sink'),
-    \ 'options': '--reverse -m -d "\t" --with-nth 1,4.. -n 1 --prompt "BTags> "'.s:q(a:query)}, args)
+    \ 'options': '--reverse -m -d "\t" --with-nth 0,3.. -n 0 --prompt "BTags> "'.s:q(a:query)}, args)
   catch
     return s:warn(v:exception)
   endtry
@@ -886,7 +886,7 @@ function! fzf#vim#snippets(...)
   let colored = map(aligned, 's:yellow(v:val[0])."\t".v:val[1]')
   return s:fzf('snippets', {
   \ 'source':  colored,
-  \ 'options': '--ansi --tiebreak=index -m -n 1 -d "\t"',
+  \ 'options': '--ansi --tiebreak=index -m -n 0 -d "\t"',
   \ 'sink':    s:function('s:inject_snippet')}, a:000)
 endfunction
 
@@ -1012,7 +1012,7 @@ function! fzf#vim#helptags(...)
   \ 'source':  'grep -H ".*" '.join(map(tags, 'skim#shellescape(v:val)')).
     \ ' | perl -n '.skim#shellescape(s:helptags_script).' | sort',
   \ 'sink':    s:function('s:helptag_sink'),
-  \ 'options': ['--ansi', '-m', '--tiebreak=begin', '--with-nth', '..-2']}, a:000)
+  \ 'options': ['--ansi', '-m', '--tiebreak=begin', '--with-nth', '..-1']}, a:000)
 endfunction
 
 " ------------------------------------------------------------------

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -636,11 +636,32 @@ endfunction
 
 function! fzf#vim#ag_interactive(dir, ...)
   let dir = empty(a:dir) ? '.' : a:dir
+  let command = 'ag --nogroup --column --color '.get(g:, 'ag_opts', '').' "{}" ' . dir
+  return call('fzf#vim#grep_interactive', extend([command, 1], a:000))
+endfunction
+
+function! fzf#vim#rg_interactive(dir, ...)
+  let dir = empty(a:dir) ? '.' : a:dir
+  let command = 'rg --color=always --line-number '.get(g:, 'ag_opts', '').' "{}" ' . dir
+  return call('fzf#vim#grep_interactive', extend([command, 1], a:000))
+endfunction
+
+function! fzf#vim#grep_interactive(command, with_column, ...)
+  let words = []
+  for word in split(a:command)
+    if word !~# '^[a-z]'
+      break
+    endif
+    call add(words, word)
+  endfor
+  let words   = empty(words) ? ['grep'] : words
+  let name    = join(words, '-')
+  let capname = join(map(words, 'toupper(v:val[0]).v:val[1:]'), '')
   let opts = {
-  \ 'source':  "none",
-  \ 'column':  1,
-  \ 'options': ['-i', '-c', 'ag --nogroup --column --color '.get(g:, 'ag_opts', '').' "{}" ' . dir,
-  \             '--ansi', '--cmd-prompt', 'Ag> ',
+  \ 'source':  'none',
+  \ 'column':  a:with_column,
+  \ 'options': ['-i', '-c', a:command,
+  \             '--ansi', '--cmd-prompt', capname.'> ',
   \             '--multi', '--bind', 'alt-a:select-all,alt-d:deselect-all',
   \             '--color', 'hl:68,hl+:110']
   \}
@@ -648,7 +669,7 @@ function! fzf#vim#ag_interactive(dir, ...)
     return s:ag_handler(a:lines, self.column)
   endfunction
   let opts['sink*'] = remove(opts, 'sink')
-  return s:fzf('rg', opts, a:000)
+  return s:fzf(name, opts, a:000)
 endfunction
 
 " query, [[ag options], options]

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -588,7 +588,7 @@ function! fzf#vim#buffers(...)
   return s:fzf('buffers', {
   \ 'source':  map(s:buflisted_sorted(), 's:format_buffer(v:val)'),
   \ 'sink*':   s:function('s:bufopen'),
-  \ 'options': '-m --tiebreak=index --ansi -d "\t" -n 0,1,2 --prompt="Buf> "'.s:q(query)
+  \ 'options': '-m --tiebreak=index --ansi -d "\t" -n 2,1..2 --prompt="Buf> "'.s:q(query)
   \}, args)
 endfunction
 
@@ -782,7 +782,7 @@ function! fzf#vim#buffer_tags(query, ...)
     return s:fzf('btags', {
     \ 'source':  s:btags_source(tag_cmds),
     \ 'sink*':   s:function('s:btags_sink'),
-    \ 'options': '--reverse -m -d "\t" --with-nth 0,3.. -n 0 --prompt "BTags> "'.s:q(a:query)}, args)
+    \ 'options': '--reverse -m -d "\t" --with-nth 1,4.. -n 1 --prompt "BTags> "'.s:q(a:query)}, args)
   catch
     return s:warn(v:exception)
   endtry
@@ -886,7 +886,7 @@ function! fzf#vim#snippets(...)
   let colored = map(aligned, 's:yellow(v:val[0])."\t".v:val[1]')
   return s:fzf('snippets', {
   \ 'source':  colored,
-  \ 'options': '--ansi --tiebreak=index -m -n 0 -d "\t"',
+  \ 'options': '--ansi --tiebreak=index -m -n 1 -d "\t"',
   \ 'sink':    s:function('s:inject_snippet')}, a:000)
 endfunction
 
@@ -1012,7 +1012,7 @@ function! fzf#vim#helptags(...)
   \ 'source':  'grep -H ".*" '.join(map(tags, 'skim#shellescape(v:val)')).
     \ ' | perl -n '.skim#shellescape(s:helptags_script).' | sort',
   \ 'sink':    s:function('s:helptag_sink'),
-  \ 'options': ['--ansi', '-m', '--tiebreak=begin', '--with-nth', '..-1']}, a:000)
+  \ 'options': ['--ansi', '-m', '--tiebreak=begin', '--with-nth', '..-2']}, a:000)
 endfunction
 
 " ------------------------------------------------------------------

--- a/autoload/fzf/vim/complete.vim
+++ b/autoload/fzf/vim/complete.vim
@@ -49,7 +49,7 @@ endif
 function! fzf#vim#complete#word(...)
   return fzf#vim#complete(s:extend({
     \ 'source': 'cat /usr/share/dict/words'},
-    \ get(a:000, 0, fzf#wrap())))
+    \ get(a:000, 0, skim#wrap())))
 endfunction
 
 " ----------------------------------------------------------------------------
@@ -73,7 +73,7 @@ function! s:file_source(prefix)
   let [dir, head, tail] = s:file_split_prefix(a:prefix)
   return printf(
     \ "cd %s && ".s:file_cmd." | sed %s",
-    \ fzf#shellescape(dir), fzf#shellescape('s:^:'.(empty(a:prefix) || a:prefix == tail ? '' : head).':'))
+    \ skim#shellescape(dir), skim#shellescape('s:^:'.(empty(a:prefix) || a:prefix == tail ? '' : head).':'))
 endfunction
 
 function! s:file_options(prefix)
@@ -130,7 +130,7 @@ function! fzf#vim#complete#path(command, ...)
   return fzf#vim#complete(s:extend({
   \ 'prefix':  s:function('s:fname_prefix'),
   \ 'source':  s:function('s:file_source'),
-  \ 'options': s:function('s:file_options')}, get(a:000, 0, fzf#wrap())))
+  \ 'options': s:function('s:file_options')}, get(a:000, 0, skim#wrap())))
 endfunction
 
 " ----------------------------------------------------------------------------
@@ -149,13 +149,13 @@ function! fzf#vim#complete#line(...)
   \ 'prefix':  '^.*$',
   \ 'source':  lines,
   \ 'options': '--tiebreak=index --ansi --nth '.nth.'.. --tabstop=1',
-  \ 'reducer': s:function('s:reduce_line')}, get(a:000, 0, fzf#wrap())))
+  \ 'reducer': s:function('s:reduce_line')}, get(a:000, 0, skim#wrap())))
 endfunction
 
 function! fzf#vim#complete#buffer_line(...)
   return fzf#vim#complete(s:extend({
   \ 'prefix': '^.*$',
-  \ 'source': fzf#vim#_uniq(getline(1, '$'))}, get(a:000, 0, fzf#wrap())))
+  \ 'source': fzf#vim#_uniq(getline(1, '$'))}, get(a:000, 0, skim#wrap())))
 endfunction
 
 let &cpo = s:cpo_save

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -91,7 +91,7 @@ if has('nvim') && get(g:, 'fzf_nvim_statusline', 1)
         highlight default fzf2 ctermfg=151 ctermbg=238 guifg=#BCDDBD guibg=#565656
         highlight default fzf3 ctermfg=252 ctermbg=238 guifg=#D9D9D9 guibg=#565656
       endif
-      setlocal statusline=%#fzf1#\ >\ %#fzf2#fz%#fzf3#f
+      setlocal statusline=%#fzf1#\ >\ %#fzf2#sk%#fzf3#im
     endif
   endfunction
 
@@ -108,7 +108,7 @@ if has('nvim') && get(g:, 'fzf_nvim_statusline', 1)
 
   augroup _fzf_statusline
     autocmd!
-    autocmd FileType fzf call s:fzf_nvim_term()
+    autocmd FileType skim call s:fzf_nvim_term()
   augroup END
 endif
 


### PR DESCRIPTION
I am trying to pickup the latest changes from fzf.vim for skim.vim. Specifically, I am interested on the support for `rg`. Some of the commands (the commands I use a lot are `Files`, `Buffers`, `Rg`) work but it looks like the `Buffers` command doesn't work. For Buffers, visually the the `windows` displays but it quickly disappears.

I am in the process of debugging the issue but I figure I let you look at it since you made the original changes to `fzf.vim`.  Any help is greatly appreciated. 