### PR TITLE
Aliases for 'fzf#run' & 'fzf#wrap' fns

### DIFF
--- a/autoload/fzf.vim
+++ b/autoload/fzf.vim
@@ -1,0 +1,8 @@
+" Glue functions for plugins calling fzf#run and/or fzf#wrap directly
+function! fzf#wrap(...)
+  return call('skim#wrap', a:000)
+endfunction
+
+function! fzf#run(...) abort
+  return call('skim#run', a:000)
+endfunction


### PR DESCRIPTION
Copied from https://github.com/lotabout/skim.vim/pull/7, but moved to the location requested by @runiq. I'm doing it since the author of #7 seems to have deleted their account.

Hoping to close https://github.com/autozimu/LanguageClient-neovim/issues/879