### PR TITLE
Support for `g:fzf_action` to change hotkeys.

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -195,6 +195,17 @@ function! s:wrap(name, opts, bang)
   else
     let wrapped = skim#wrap(a:name, opts, a:bang)
   endif
+
+  " Action: g:fzf_action
+  if !s:has_any(opts, ['sink', 'sinklist', 'sink*'])
+    let wrapped._action = get(g:, 'fzf_action', s:default_action)
+    let wrapped.options .= ' --expect='.join(keys(opts._action), ',')
+    function! opts.sinklist(lines) abort
+      return s:common_sink(self._action, a:lines)
+    endfunction
+    let wrapped['sink*'] = opts.sinklist " For backward compatibility
+  endif
+
   return wrapped
 endfunction
 


### PR DESCRIPTION
*As a warning, i have never written vim files before so this is a first-cut.*

With fzf, if you specify the following (which is the default):
```
let g:fzf_action = {
  \ 'ctrl-t': 'tab split',
  \ 'ctrl-x': 'split',
  \ 'ctrl-v': 'vsplit' }
```

It is possible to override the default hotkey for opening files from the fzf view using `g:fzf_action`.
In my case i have `ctl-x` already mapped to an action, so i cannot open
a file in split-view using fzf/skim. Changing the `g:fzf_action` allows
me to change the hotkey for split-view to `ctrl-e` (or anything)

```
let g:fzf_action = {
  \ 'ctrl-t': 'tab split',
  \ 'ctrl-e': 'split',
  \ 'ctrl-v': 'vsplit' }
```