### PR TITLE
Fix skim version check

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -73,7 +73,7 @@ function! s:check_requirements()
     throw "skim#exec function not found. You need to upgrade Vim plugin from the main fzf repository ('junegunn/fzf')"
   endif
   let exec = skim#exec()
-  let fzf_version = matchstr(systemlist(exec .. ' --version')[0], '[0-9.]*')
+  let fzf_version = matchstr(systemlist(exec .. ' --version')[0], '[0-9\.]\+')
 
   if s:version_requirement(fzf_version, s:min_version)
     let s:checked = 1

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -52,9 +52,10 @@ function! s:version_requirement(val, min)
   let val = split(a:val, '\.')
   let min = split(a:min, '\.')
   for idx in range(0, len(min) - 1)
-    let v = get(val, idx, 0)
-    if     v < min[idx] | return 0
-    elseif v > min[idx] | return 1
+    let v = str2nr(get(val, idx, 0))
+    let m = str2nr(min[idx])
+    if     v < m | return 0
+    elseif v > m | return 1
     endif
   endfor
   return 1


### PR DESCRIPTION
fix: support future clap-styled version output of skim

The clap crate >= 3 as used in skim has a new default version option
that resolves to a different output style including the application name
in front of the actual version.

Switch the matchstr mode to magic and allow an optional `sk `
application name prefix when matching for the current version.
This allows to have a future proof version matcher which is also
backwards compatible.