### PR TITLE
Fix version number extraction and comparison

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -52,9 +52,10 @@ function! s:version_requirement(val, min)
   let val = split(a:val, '\.')
   let min = split(a:min, '\.')
   for idx in range(0, len(min) - 1)
-    let v = get(val, idx, 0)
-    if     v < min[idx] | return 0
-    elseif v > min[idx] | return 1
+    let v = get(val, idx, 0) + 0
+    let m = min[idx] + 0
+    if     v < m | return 0
+    elseif v > m | return 1
     endif
   endfor
   return 1
@@ -72,7 +73,7 @@ function! s:check_requirements()
     throw "skim#exec function not found. You need to upgrade Vim plugin from the main fzf repository ('junegunn/fzf')"
   endif
   let exec = skim#exec()
-  let fzf_version = matchstr(systemlist(exec .. ' --version')[0], '[0-9.]*')
+  let fzf_version = matchstr(systemlist(exec .. ' --version')[0], '[0-9.]\+')
 
   if s:version_requirement(fzf_version, s:min_version)
     let s:checked = 1


### PR DESCRIPTION
-   Fix the regexp so that matchstr won't match empty string if `skim
    --version` doesn't start with the version number.

-   Fix version number comparison so that it compares major/minor/micro
    versions as number numbers instead of strings (so that 10 > 9).

The vim plugin recently started to break when using any command, such as `:Rg`, complaining that I "need to update fzf".  I don't know if the output of `sk --version` changed recently and broke the code, but the regular expression `'[0-9.]*'` in the `matchstr` statement doesn't match the string "sk 0.10.2" which `sk --version` prints.  The VIM documentation of `match()` says:

>   Note that a match at the start is preferred, thus when the
>   pattern is using "*" (any number of matches) it tends to find
>   zero matches at the start instead of a number of matches
>   further down in the text.

So I changed `*` to `\+`.

It is also comparing version numbers as strings, which was OK when the major/minor/micro versions all had only one digit. I fixed that, too.